### PR TITLE
Suggest a username if it is already taken

### DIFF
--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,8 +135,7 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					const suggestion = username + '123';
-					showError(usernameInput, username_notify, '[[error:username-taken]] Try "${suggestion}" ');
+					showError(usernameInput, username_notify, `[[error:username-taken]] Try "${username}123" instead.`);
 				}
 
 				callback();

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -135,7 +135,8 @@ define('forum/register', [
 				if (results.every(obj => obj.status === 'rejected')) {
 					showSuccess(usernameInput, username_notify, successIcon);
 				} else {
-					showError(usernameInput, username_notify, '[[error:username-taken]]');
+					const suggestion = username + '123';
+					showError(usernameInput, username_notify, '[[error:username-taken]] Try "${suggestion}" ');
 				}
 
 				callback();


### PR DESCRIPTION
Closes #1

Updated  public/src/client/register.js.

Instead of only showing the error message, it now suggests `username123` as an alternative.

Testing:
2. Tried to register as 'aadalbek'
4. The error showed up along with a suggestion 'aadalbek123'.