### PR TITLE
Added resolved status fields to topics database (Task 6, Issue #12)

### DIFF
--- a/RESOLVED_FIELDS_INTERFACE.md
+++ b/RESOLVED_FIELDS_INTERFACE.md
@@ -1,0 +1,42 @@
+# Resolved Status Database Fields
+
+## Fields Added to Topics
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `resolved` | Integer (0/1) | 0 | Topic resolved status (0=unresolved, 1=resolved) |
+| `resolvedBy` | Integer/null | null | User ID who marked as resolved |
+| `resolvedAt` | Integer/null | null | Unix timestamp (ms) when resolved |
+
+## Usage
+
+### Reading Status
+```javascript
+// Single topic
+const resolved = await Topics.getTopicField(tid, 'resolved');
+const isResolved = resolved === 1;
+
+// Multiple fields
+const data = await Topics.getTopicFields(tid, ['resolved', 'resolvedBy', 'resolvedAt']);
+```
+
+### Setting Status (API Team - Issue #5)
+```javascript
+// Mark resolved
+await Topics.setTopicFields(tid, {
+    resolved: 1,
+    resolvedBy: uid,
+    resolvedAt: Date.now()
+});
+
+// Mark unresolved
+await Topics.setTopicFields(tid, {
+    resolved: 0,
+    resolvedBy: null,
+    resolvedAt: null
+});
+```
+
+## Implementation Files
+- Schema: `src/topics/data.js:17`
+- Migration: `src/upgrades/4.3.3/add_resolved_fields_to_topics.js`

--- a/RESOLVED_FIELDS_INTERFACE.md
+++ b/RESOLVED_FIELDS_INTERFACE.md
@@ -40,3 +40,4 @@ await Topics.setTopicFields(tid, {
 ## Implementation Files
 - Schema: `src/topics/data.js:17`
 - Migration: `src/upgrades/4.3.3/add_resolved_fields_to_topics.js`
+- OpenAPI Schema: `public/openapi/components/schemas/TopicObject.yaml:281-292`

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -274,10 +274,10 @@ TopicObjectSlim:
                 description: The topic thumbnail filename
               path:
                 type: string
-                description: The relative path to the thumbnail
+                description: Path to topic thumbnail without upload_url prefix
               url:
                 type: string
-                description: The full URL to the thumbnail
+                description: Relative path to the topic thumbnail
         # Resolved status fields for marking topics as resolved
         resolved:
           type: number

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -274,10 +274,22 @@ TopicObjectSlim:
                 description: The topic thumbnail filename
               path:
                 type: string
-                description: Path to topic thumbnail without upload_url prefix
+                description: The relative path to the thumbnail
               url:
                 type: string
-                description: Relative path to the topic thumbnail
+                description: The full URL to the thumbnail
+        # Resolved status fields for marking topics as resolved
+        resolved:
+          type: number
+          description: Whether the topic is marked as resolved (0=unresolved, 1=resolved)
+        resolvedBy:
+          type: number
+          nullable: true
+          description: The user ID who marked the topic as resolved
+        resolvedAt:
+          type: number
+          nullable: true
+          description: Unix timestamp when the topic was marked as resolved
     - type: object
       description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
       properties:

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -14,6 +14,7 @@ const intFields = [
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
 	'lastposttime', 'deleterUid',
+	'resolved', 'resolvedBy', 'resolvedAt',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -14,7 +14,7 @@ const intFields = [
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
 	'lastposttime', 'deleterUid',
-	'resolved', 'resolvedBy', 'resolvedAt',
+	'resolved', 'resolvedBy', 'resolvedAt', // Resolved status: boolean flag, resolver uid, timestamp
 ];
 
 module.exports = function (Topics) {

--- a/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
+++ b/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
@@ -6,6 +6,7 @@ module.exports = {
 	name: 'Add resolved status fields to topics',
 	timestamp: Date.UTC(2024, 8, 26), // September 26, 2024 (month is 0-indexed)
 	method: async function () {
+		// Adds resolved fields to all existing topics with default values
 		const { progress } = this;
 
 		const db = require('../../database');
@@ -13,6 +14,7 @@ module.exports = {
 		await batch.processSortedSet('topics:tid', async (tids) => {
 			progress.incr(tids.length);
 
+			// Initialize resolved fields: 0=unresolved, null for user/timestamp
 			const bulkSet = tids.map(tid => [
 				`topic:${tid}`,
 				{

--- a/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
+++ b/src/upgrades/4.3.3/add_resolved_fields_to_topics.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const batch = require('../../batch');
+
+module.exports = {
+	name: 'Add resolved status fields to topics',
+	timestamp: Date.UTC(2024, 8, 26), // September 26, 2024 (month is 0-indexed)
+	method: async function () {
+		const { progress } = this;
+
+		const db = require('../../database');
+
+		await batch.processSortedSet('topics:tid', async (tids) => {
+			progress.incr(tids.length);
+
+			const bulkSet = tids.map(tid => [
+				`topic:${tid}`,
+				{
+					resolved: 0,
+					resolvedBy: null,
+					resolvedAt: null,
+				},
+			]);
+
+			await db.setObjectBulk(bulkSet);
+		}, {
+			batch: 500,
+			progress,
+		});
+	},
+};


### PR DESCRIPTION
Closes Task 6, Issue #12

  ## What
  Adds database support for marking topics as resolved.

  ## Changes
  - Added `resolved`, `resolvedBy`, `resolvedAt` fields to topic schema
  - Created migration script for existing topics (v4.3.3)
  - Updated OpenAPI schema definitions to include resolved fields
  - Added interface documentation in `RESOLVED_FIELDS_INTERFACE.md`

  ## Usage
  ```javascript
  // Check if topic is resolved
  const resolved = await Topics.getTopicField(tid, 'resolved');
  const isResolved = resolved === 1;

  // Get all resolved fields
  const data = await Topics.getTopicFields(tid, ['resolved', 'resolvedBy', 'resolvedAt']);